### PR TITLE
Fix compilation and add spawn_sync method

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -9,47 +9,56 @@ use glib::translate::*;
 use glib_ffi;
 use Terminal;
 
+macro_rules! option_to_ptr {
+    ($e:expr) => {
+        match $e {
+            Some(value) => value.to_glib_none().0,
+            None => ptr::null()
+        }
+    };
+}
+
 impl Terminal {
     pub fn set_color_background(&self, background: &gdk::RGBA) {
         unsafe {
-            ffi::vte_terminal_set_color_background(self.to_glib_none().0, background);
+            ffi::vte_terminal_set_color_background(self.to_glib_none().0, background.to_glib_none().0);
         }
     }
 
     pub fn set_color_bold(&self, bold: Option<&gdk::RGBA>) {
         unsafe {
-            ffi::vte_terminal_set_color_bold(self.to_glib_none().0, option_to_ptr(bold));
+            ffi::vte_terminal_set_color_bold(self.to_glib_none().0, option_to_ptr!(bold));
         }
     }
 
     pub fn set_color_cursor(&self, cursor_background: Option<&gdk::RGBA>) {
         unsafe {
-            ffi::vte_terminal_set_color_cursor(self.to_glib_none().0, option_to_ptr(cursor_background));
+            ffi::vte_terminal_set_color_cursor(self.to_glib_none().0, option_to_ptr!(cursor_background));
         }
     }
 
     #[cfg(feature = "v0_44")]
     pub fn set_color_cursor_foreground(&self, cursor_foreground: Option<&gdk::RGBA>) {
         unsafe {
-            ffi::vte_terminal_set_color_cursor_foreground(self.to_glib_none().0, option_to_ptr(cursor_foreground));
+            ffi::vte_terminal_set_color_cursor_foreground(self.to_glib_none().0, option_to_ptr!(cursor_foreground));
         }
     }
 
     pub fn set_color_foreground(&self, foreground: &gdk::RGBA) {
         unsafe {
-            ffi::vte_terminal_set_color_foreground(self.to_glib_none().0, foreground);
+            ffi::vte_terminal_set_color_foreground(self.to_glib_none().0, foreground.to_glib_none().0);
         }
     }
 
     pub fn set_color_highlight(&self, highlight_background: Option<&gdk::RGBA>) {
         unsafe {
-            ffi::vte_terminal_set_color_highlight(self.to_glib_none().0, option_to_ptr(highlight_background));
+            ffi::vte_terminal_set_color_highlight(self.to_glib_none().0, option_to_ptr!(highlight_background));
         }
     }
 
     pub fn set_color_highlight_foreground(&self, highlight_foreground: Option<&gdk::RGBA>) {
         unsafe {
-            ffi::vte_terminal_set_color_highlight_foreground(self.to_glib_none().0, option_to_ptr(highlight_foreground));
+            ffi::vte_terminal_set_color_highlight_foreground(self.to_glib_none().0, option_to_ptr!(highlight_foreground));
         }
     }
 
@@ -62,12 +71,5 @@ impl Terminal {
                 glib_ffi::G_SPAWN_DEFAULT, None, ptr::null_mut(), None, -1, ptr::null_mut(),
                 None, ptr::null_mut());
         }
-    }
-}
-
-fn option_to_ptr<T>(value: Option<&T>) -> *const T {
-    match value {
-        Some(value) => value as *const _,
-        None => ptr::null(),
     }
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,11 +1,9 @@
-#[cfg(feature="v0_48")]
 use std::path::PathBuf;
 use std::ptr;
 
 use ffi;
 use gdk;
 use glib::translate::*;
-#[cfg(feature="v0_48")]
 use glib_ffi;
 use Terminal;
 
@@ -59,6 +57,15 @@ impl Terminal {
     pub fn set_color_highlight_foreground(&self, highlight_foreground: Option<&gdk::RGBA>) {
         unsafe {
             ffi::vte_terminal_set_color_highlight_foreground(self.to_glib_none().0, option_to_ptr!(highlight_foreground));
+        }
+    }
+
+    pub fn spawn_sync(&self, working_directory: Option<PathBuf>, argv: &[&str], envv: &[&str]) {
+        let directory = working_directory.as_ref().map(|path_buf| path_buf.as_path());
+        unsafe {
+            ffi::vte_terminal_spawn_sync(self.to_glib_none().0, ffi::VTE_PTY_DEFAULT,
+                directory.to_glib_none().0, argv.to_glib_none().0, envv.to_glib_none().0,
+                glib_ffi::G_SPAWN_DEFAULT, None, ptr::null_mut(), ptr::null_mut(), ptr::null_mut(), ptr::null_mut());
         }
     }
 


### PR DESCRIPTION
When I tried to build this, I got several errors similar to this:

```
error[E0308]: mismatched types
  --> src/terminal.rs:15:75
   |
15 |             ffi::vte_terminal_set_color_background(self.to_glib_none().0, background);
   |                                                                           ^^^^^^^^^^ expected struct `gdk_sys::GdkRGBA`, found struct `gdk::RGBA`
   |
   = note: expected type `*const gdk_sys::GdkRGBA`
   = note:    found type `&gdk::RGBA`
```

The first commit here fixes these errors, so that I can compile the crate.

The second commit adds the `spawn_sync` method, mostly as a copy of `spawn_async`; `spawn_sync` is available in older versions of vte, including the one on my computer.

I'm quite new to rust, so let me know if I've done anything wrong.